### PR TITLE
Add missing QDataStream include for qt5

### DIFF
--- a/qtlocalpeer.cpp
+++ b/qtlocalpeer.cpp
@@ -42,6 +42,7 @@
 #include "qtlocalpeer.h"
 #include <QCoreApplication>
 #include <QTime>
+#include <QDataStream>
 
 #if defined(Q_OS_WIN)
 #include <QLibrary>


### PR DESCRIPTION
When building mysms-desktop-app on Centos 7, I received the following error after running:

```
$ qmake-qt5
$ make
```

```
qtlocalpeer.cpp: In member function ‘bool QtLocalPeer::sendMessage(const QString&, int)’:
qtlocalpeer.cpp:160:19: error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(&socket);
                   ^
qtlocalpeer.cpp: In member function ‘void QtLocalPeer::receiveConnection()’:
qtlocalpeer.cpp:180:26: error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(socket);
                          ^
make: *** [qtlocalpeer.o] Error 1
```

After taking a look at qtlocalpeer.cpp, I discovered it was missing the QDataStream needed in qt5.  I added it in, then ran

```
$ make clean
$ rm Makefile
$ qmake-qt5
$ make
$ make install
```

Everything worked, and mysms desktop built and works correctly on my Centos 7 machine.

I'm making this pull request just in case anyone else wants to build mysms on a different platform, since I suspect that this missing include affects more than just Centos 7.